### PR TITLE
fixes #2: unit test failure under JDK17

### DIFF
--- a/src/changelog.html
+++ b/src/changelog.html
@@ -47,6 +47,7 @@
 <p><b>1.0.0</b> -- To be determined.</p>
 <ul>
     <li>Initial release</li>
+    <li>Fixes <a href="https://github.com/igniterealtime/openfire-exi-plugin/issues/2">issue #2</a>: Unit test fail under JDK 17</li>
 </ul>
 
 </body>

--- a/src/main/java/cl/clayster/exi/EXIFilter.java
+++ b/src/main/java/cl/clayster/exi/EXIFilter.java
@@ -180,7 +180,7 @@ public class EXIFilter extends IoFilterAdapter
         try {
             // obtener el schemas File del servidor y transformarlo a un elemento XML
             Element serverSchemas;
-            String schemasFileContent = EXIUtils.readFile(EXIUtils.schemasFileLocation);
+            String schemasFileContent = EXIUtils.readFile(EXIUtils.getSchemasFileLocation());
             if (schemasFileContent == null) {
                 return null;
             }
@@ -332,7 +332,7 @@ public class EXIFilter extends IoFilterAdapter
         final MessageDigest md = MessageDigest.getInstance("MD5");
         final String schemaId = EXIUtils.bytesToHex(md.digest(canonicalSchema.asXML().getBytes()));
 
-        final Path fileName = EXIUtils.exiFolder.resolve(schemaId + ".xsd");
+        final Path fileName = EXIUtils.getExiFolder().resolve(schemaId + ".xsd");
         try (final FileWriter fileWriter = new FileWriter(fileName.toFile()))
         {
             final XMLWriter writer = new XMLWriter(fileWriter, OutputFormat.createPrettyPrint());
@@ -402,7 +402,7 @@ public class EXIFilter extends IoFilterAdapter
         content = content.substring(content.indexOf('>') + 1, content.indexOf("</"));
         byte[] outputBytes = Base64.decode(content);
 
-        final Path filePath = EXIUtils.schemasFolder.resolve(Calendar.getInstance().getTimeInMillis() + ".xsd");
+        final Path filePath = EXIUtils.getSchemasFolder().resolve(Calendar.getInstance().getTimeInMillis() + ".xsd");
         try (final OutputStream out = Files.newOutputStream(filePath)) {
             out.write(outputBytes);
         }
@@ -414,7 +414,7 @@ public class EXIFilter extends IoFilterAdapter
     void uploadCompressedMissingSchema(byte[] content, String contentType, String md5Hash, String bytes, IoSession session)
         throws IOException, NoSuchAlgorithmException, DocumentException, EXIException, SAXException, TransformerException
     {
-        Path filePath = EXIUtils.schemasFolder.resolve(Calendar.getInstance().getTimeInMillis() + ".xsd");
+        Path filePath = EXIUtils.getSchemasFolder().resolve(Calendar.getInstance().getTimeInMillis() + ".xsd");
 
         if (!"text".equals(contentType) && md5Hash != null && bytes != null) {
             String xml = "";
@@ -449,12 +449,12 @@ public class EXIFilter extends IoFilterAdapter
 
         // Create schemas file if it does not exist yet.
         final Document document;
-        if (!Files.exists(EXIUtils.schemasFileLocation)) {    // no more schemas (only the new one)
+        if (!Files.exists(EXIUtils.getSchemasFileLocation())) {    // no more schemas (only the new one)
             document = DocumentHelper.createDocument();
             document.addElement("setupResponse");
         } else {
             // obtener el schemas File del servidor y transformarlo a un elemento XML
-            final String content = String.join("", Files.readAllLines(EXIUtils.schemasFileLocation));
+            final String content = String.join("", Files.readAllLines(EXIUtils.getSchemasFileLocation()));
             document = DocumentHelper.parseText(content);
         }
 
@@ -472,7 +472,7 @@ public class EXIFilter extends IoFilterAdapter
         // XEP-0322 wants canonical schemas to be ordered by namespace.
         schemas.sort(Comparator.comparing(element -> element.attributeValue("ns")));
 
-        try (final FileWriter fileWriter = new FileWriter(EXIUtils.schemasFileLocation.toFile()))
+        try (final FileWriter fileWriter = new FileWriter(EXIUtils.getSchemasFileLocation().toFile()))
         {
             final XMLWriter writer = new XMLWriter(fileWriter, OutputFormat.createPrettyPrint());
             writer.write(document);
@@ -483,7 +483,7 @@ public class EXIFilter extends IoFilterAdapter
     static void addNewSchemaToCanonicalSchema(Path fileLocation, IoSession session) throws IOException, DocumentException
     {
         // obtener el schemas File del servidor y transformarlo a un elemento XML
-        final Path canonicalSchema = EXIUtils.exiFolder.resolve(session.getAttribute(EXIUtils.SCHEMA_ID) + ".xsd");
+        final Path canonicalSchema = EXIUtils.getExiFolder().resolve(session.getAttribute(EXIUtils.SCHEMA_ID) + ".xsd");
         EXIUtils.addNewSchemaToCanonicalSchema(canonicalSchema, fileLocation);
         session.setAttribute(EXIUtils.CANONICAL_SCHEMA_LOCATION, canonicalSchema.toAbsolutePath().toString());
     }
@@ -492,7 +492,7 @@ public class EXIFilter extends IoFilterAdapter
 
     private void saveDownloadedSchema(String content, IoSession session) throws NoSuchAlgorithmException, IOException, DocumentException
     {
-        Path filePath = EXIUtils.schemasFolder.resolve(Calendar.getInstance().getTimeInMillis() + ".xsd");
+        Path filePath = EXIUtils.getSchemasFolder().resolve(Calendar.getInstance().getTimeInMillis() + ".xsd");
 
         OutputStream out = Files.newOutputStream(filePath);
         out.write(content.getBytes());

--- a/src/main/java/cl/clayster/exi/EXISetupConfiguration.java
+++ b/src/main/java/cl/clayster/exi/EXISetupConfiguration.java
@@ -125,9 +125,9 @@ public class EXISetupConfiguration extends DefaultEXIFactory
     public Path getCanonicalSchemaLocation()
     {
         if (schemaId != null) {
-            return EXIUtils.exiFolder.resolve(schemaId + ".xsd");
+            return EXIUtils.getExiFolder().resolve(schemaId + ".xsd");
         } else {
-            return EXIUtils.defaultCanonicalSchemaLocation;
+            return EXIUtils.getDefaultCanonicalSchemaLocation();
         }
     }
 
@@ -217,7 +217,7 @@ public class EXISetupConfiguration extends DefaultEXIFactory
             Log.warn("Exception while trying to save configuration.", e);
         }
 
-        Path fileName = EXIUtils.exiFolder.resolve(configurationId + ".xml");
+        Path fileName = EXIUtils.getExiFolder().resolve(configurationId + ".xml");
         if (Files.exists(fileName)) {
             return true;
         } else {
@@ -238,7 +238,7 @@ public class EXISetupConfiguration extends DefaultEXIFactory
      */
     public static EXISetupConfiguration parseQuickConfigId(String configId) throws DocumentException
     {
-        Path fileLocation = EXIUtils.exiFolder.resolve(configId + ".xml");
+        Path fileLocation = EXIUtils.getExiFolder().resolve(configId + ".xml");
         String content = EXIUtils.readFile(fileLocation);
         if (content == null)
             return null;

--- a/src/main/java/cl/clayster/exi/SchemaIdResolver.java
+++ b/src/main/java/cl/clayster/exi/SchemaIdResolver.java
@@ -40,7 +40,7 @@ public class SchemaIdResolver implements com.siemens.ct.exi.core.SchemaIdResolve
 			return GrammarFactory.newInstance().createGrammars(EXIUtils.defaultCanonicalSchemaLocation);
 		} else {
 		*/
-        final Path schemaIdPath = EXIUtils.exiFolder.resolve(schemaId + ".xsd");
+        final Path schemaIdPath = EXIUtils.getExiFolder().resolve(schemaId + ".xsd");
         if (Files.exists(schemaIdPath)) {
             try {
                 Log.trace("Found schema file for schema ID '{}'. Using it to populate grammar.", schemaId);

--- a/src/main/java/cl/clayster/exi/SchemaResolver.java
+++ b/src/main/java/cl/clayster/exi/SchemaResolver.java
@@ -46,12 +46,12 @@ public class SchemaResolver implements XMLEntityResolver
         namespaceToPath = new HashMap<>();
 
         // Iterate over all files to record a namespace-to-path mapping.
-        if (!Files.isDirectory(EXIUtils.schemasFolder)) {
-            throw new IllegalStateException("Configured schema folder is not a directory: " + EXIUtils.schemasFolder);
+        if (!Files.isDirectory(EXIUtils.getSchemasFolder())) {
+            throw new IllegalStateException("Configured schema folder is not a directory: " + EXIUtils.getSchemasFolder());
         }
 
         final Set<Path> xsds;
-        try (final Stream<Path> stream = Files.walk(EXIUtils.schemasFolder, 1)) {
+        try (final Stream<Path> stream = Files.walk(EXIUtils.getSchemasFolder(), 1)) {
             xsds = stream
                 .filter(Files::isRegularFile)
                 .filter(path -> path.getFileName().toString().endsWith(".xsd"))
@@ -59,7 +59,7 @@ public class SchemaResolver implements XMLEntityResolver
         }
 
         if (xsds.isEmpty()) {
-            throw new IllegalStateException("Configured schema folder contains no files: " + EXIUtils.schemasFolder);
+            throw new IllegalStateException("Configured schema folder contains no files: " + EXIUtils.getSchemasFolder());
         }
 
         for (final Path xsd : xsds) {
@@ -75,8 +75,8 @@ public class SchemaResolver implements XMLEntityResolver
         namespaceToPath.remove("urn:xmpp:exi:cs");
 
         // Add DTDs
-        this.namespaceToPath.put("-//W3C//DTD XMLSCHEMA 200102//EN", EXIUtils.schemasFolder.resolve("XMLSchema.dtd"));
-        this.namespaceToPath.put("datatypes", EXIUtils.schemasFolder.resolve("datatypes.dtd"));
+        this.namespaceToPath.put("-//W3C//DTD XMLSCHEMA 200102//EN", EXIUtils.getSchemasFolder().resolve("XMLSchema.dtd"));
+        this.namespaceToPath.put("datatypes", EXIUtils.getSchemasFolder().resolve("datatypes.dtd"));
     }
 
     public XMLInputSource resolveEntity(XMLResourceIdentifier resourceIdentifier) throws XNIException, IOException

--- a/src/main/java/cl/clayster/exi/UploadSchemaFilter.java
+++ b/src/main/java/cl/clayster/exi/UploadSchemaFilter.java
@@ -140,7 +140,7 @@ public class UploadSchemaFilter extends IoFilterAdapter
     void uploadCompressedMissingSchema(byte[] content, String contentType, String md5Hash, String bytes, IoSession session)
         throws IOException, NoSuchAlgorithmException, DocumentException, EXIException, SAXException, TransformerException
     {
-        Path filePath = EXIUtils.schemasFolder.resolve(Calendar.getInstance().getTimeInMillis() + ".xsd");
+        Path filePath = EXIUtils.getSchemasFolder().resolve(Calendar.getInstance().getTimeInMillis() + ".xsd");
 
         if (!"text".equals(contentType) && md5Hash != null && bytes != null) {
             String xml = "";
@@ -159,7 +159,7 @@ public class UploadSchemaFilter extends IoFilterAdapter
     void uploadMissingSchema(String content, IoSession session)
         throws IOException, NoSuchAlgorithmException, DocumentException, EXIException, SAXException, TransformerException
     {
-        Path filePath = EXIUtils.schemasFolder.resolve(Calendar.getInstance().getTimeInMillis() + ".xsd");
+        Path filePath = EXIUtils.getSchemasFolder().resolve(Calendar.getInstance().getTimeInMillis() + ".xsd");
         OutputStream out = Files.newOutputStream(filePath);
 
         content = content.substring(content.indexOf('>') + 1, content.indexOf("</"));

--- a/src/test/java/cl/clayster/exi/EXICodedFilterTest.java
+++ b/src/test/java/cl/clayster/exi/EXICodedFilterTest.java
@@ -48,19 +48,14 @@ import static org.junit.Assert.assertNotNull;
 @RunWith(MockitoJUnitRunner.class)
 public class EXICodedFilterTest
 {
-    private final static Path oldSchemasFolder = EXIUtils.schemasFolder;
-    private final static Path oldSchemasFileLocation = EXIUtils.schemasFileLocation;
-    private final static Path oldExiFolder = EXIUtils.exiFolder;
-    private final static Path oldDefaultCanonicalSchemaLocation = EXIUtils.defaultCanonicalSchemaLocation;
-
     @BeforeClass
     public static void mockFolders() throws Exception {
-        EXIUtils.schemasFolder = Files.createTempDirectory("unit-test-classes-");
+        EXIUtils.setSchemasFolder( Files.createTempDirectory("unit-test-classes-") );
 
         // Copy all content to temp folder
         try (final Stream<Path> stream = Files.walk(Paths.get("classes"))) {
             stream.forEach(source -> {
-                Path destination = EXIUtils.schemasFolder.resolve(source.getFileName());
+                Path destination = EXIUtils.getSchemasFolder().resolve(source.getFileName());
                 try {
                     Files.copy(source, destination);
                 } catch (IOException e) {
@@ -69,20 +64,13 @@ public class EXICodedFilterTest
             });
         }
 
-        EXIUtils.schemasFileLocation = EXIUtils.schemasFolder.resolve("schemas.xml");
-        EXIUtils.exiFolder = EXIUtils.schemasFolder.resolve("canonicalSchemas");
-        EXIUtils.defaultCanonicalSchemaLocation = EXIUtils.exiFolder.resolve("defaultSchema.xsd");
-
         EXIUtils.generateSchemasFile();
         EXIUtils.generateDefaultCanonicalSchema();
     }
 
     @AfterClass
     public static void restoreFolders() {
-        EXIUtils.schemasFolder = oldSchemasFolder;
-        EXIUtils.schemasFileLocation = oldSchemasFileLocation;
-        EXIUtils.exiFolder = oldExiFolder;
-        EXIUtils.defaultCanonicalSchemaLocation = oldDefaultCanonicalSchemaLocation;
+        EXIUtils.setSchemasFolder(null);
     }
 
     /**


### PR DESCRIPTION
This addresses a staticly loaded path that doesn't exist when unit tests are executed. Apparently, this trips up JDK 17 more than earlier JDKs.

Not the cleanest of solutions, but barring a major refactoring, this will do.